### PR TITLE
Added support for Arch Linux

### DIFF
--- a/cve-2024-3094-detector/cve-2024-3094-detector.sh
+++ b/cve-2024-3094-detector/cve-2024-3094-detector.sh
@@ -31,7 +31,7 @@ elif [ -f /etc/arch-release ]; then
     # Running on Arch - vulnerable versions are knowns: 5.6.0-1 and 5.6.1-1
     xz_version=$(pacman -Q xz | sed 's/^xz //')
     if [[ "$xz_version" =~ ^5\.6\.[0-1]-1$ ]]; then
-        malicious_xz=0
+        malicious_xz=1
     fi
 
 else

--- a/cve-2024-3094-detector/cve-2024-3094-detector.sh
+++ b/cve-2024-3094-detector/cve-2024-3094-detector.sh
@@ -27,8 +27,15 @@ if [ -f /etc/alpine-release ]; then
         malicious_xz=0
     fi
 
+elif [ -f /etc/arch-release ]; then
+    # Running on Arch - vulnerable versions are knowns: 5.6.0-1 and 5.6.1-1
+    xz_version=$(pacman -Q xz | sed 's/^xz //')
+    if [[ "$xz_version" =~ ^5\.6\.[0-1]-1$ ]]; then
+        malicious_xz=0
+    fi
+
 else
-    # Not Alpine - Check if xz version is >= 5.5.0
+    # Running on other Linux - Check if xz version is >= 5.5.0
     xz_version=$(strings "$(which xz)" | awk '/xz \(XZ Utils/ {print $4}')
     if awk -vv="$xz_version" 'BEGIN {split(v,a,"."); if (a[1]>=5 && a[2]>=5) exit 0; else exit 1}'; then
 	malicious_xz=0


### PR DESCRIPTION
Hi, I changed your script a bit to also check for vulnerable xz versions on Arch Linux.

Vulnerable versions in Arch are 5.6.0-1 and 5.6.1-1. Version 5.6.1-2 has removed the backdoor (earlier versions don't have it).