### PR TITLE
Correct bash runtime error: 'integer expression expected'

### DIFF
--- a/cve-2024-3094-detector/cve-2024-3094-detector.sh
+++ b/cve-2024-3094-detector/cve-2024-3094-detector.sh
@@ -108,23 +108,25 @@ else
     echo -e "${GREEN}NO${NC}"
 fi
 
-echo -ne "LZMA vulnerable version: " 
-if [ "$byte_pattern_1_found" -eq 1 ] && [ "$byte_pattern_2_found" -eq 1 ]; then
-    echo -e "${RED}YES${NC}"
-    echo -e "  ${RED}Specific Prologue byte pattern matched${NC}"
-    echo -e "  ${RED}Encoded Strings byte patterns matched${NC}"
-elif [ "$byte_pattern_1_found" -eq 1 ]; then
-    echo -e "${RED}YES${NC}"
-    echo -e "  ${RED}Specific Prologue byte pattern matched${NC}"
-    echo -e "  ${GREEN}Encoded Strings byte patterns NOT matched${NC}"
-elif [ "$byte_pattern_2_found" -eq 1 ]; then
-    echo -e "${RED}YES${NC}"
-    echo -e "  ${GREEN}Specific Prologue byte pattern NOT matched${NC}"
-    echo -e "  ${RED}Encoded Strings byte patterns matched${NC}"
-else
-    echo -e "${GREEN}NO${NC}"
-    echo -e "  ${GREEN}Specific Prologue byte pattern NOT matched${NC}"
-    echo -e "  ${GREEN}Encoded Strings byte patterns NOT matched${NC}"
+if [ "$lzma_found" -eq 1 ] ; then
+    echo -ne "LZMA vulnerable version: "
+    if [ "$byte_pattern_1_found" -eq 1 ] && [ "$byte_pattern_2_found" -eq 1 ]; then
+        echo -e "${RED}YES${NC}"
+        echo -e "  ${RED}Specific Prologue byte pattern matched${NC}"
+        echo -e "  ${RED}Encoded Strings byte patterns matched${NC}"
+    elif [ "$byte_pattern_1_found" -eq 1 ]; then
+        echo -e "${RED}YES${NC}"
+        echo -e "  ${RED}Specific Prologue byte pattern matched${NC}"
+        echo -e "  ${GREEN}Encoded Strings byte patterns NOT matched${NC}"
+    elif [ "$byte_pattern_2_found" -eq 1 ]; then
+        echo -e "${RED}YES${NC}"
+        echo -e "  ${GREEN}Specific Prologue byte pattern NOT matched${NC}"
+        echo -e "  ${RED}Encoded Strings byte patterns matched${NC}"
+    else
+        echo -e "${GREEN}NO${NC}"
+        echo -e "  ${GREEN}Specific Prologue byte pattern NOT matched${NC}"
+        echo -e "  ${GREEN}Encoded Strings byte patterns NOT matched${NC}"
+    fi
 fi
 
 # Output conclusion


### PR DESCRIPTION
Correct bash runtime error: 'integer expression expected' if lzma is not found.